### PR TITLE
Chore/refactor routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ wheels/
 # Virtual environments
 .venv/
 
+# Banco de dados local para testes
+data.db
+
 # Environment variables
 # Em um novo projeto descomente a linha abaixo
 # .env

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -1,0 +1,7 @@
+from typing import Annotated
+
+from app.core.db_provider import get_session
+from sqlalchemy.orm import Session
+from fastapi import Depends
+
+SessionDep = Annotated[Session, Depends(get_session)]

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+from app.api.routes import user, content
+
+api_router = APIRouter()
+api_router.include_router(user.router)
+api_router.include_router(content.router)

--- a/app/api/routes/content.py
+++ b/app/api/routes/content.py
@@ -5,10 +5,10 @@ from app.schemas.content import ContentCreate, ContentResponse, ContentUpdate
 from app.core.db_provider import get_session
 from app.services import content
 
-content_router = APIRouter()
+router = APIRouter()
 
 
-@content_router.post('/create-content/', 
+@router.post('/create-content/', 
                      response_model=ContentResponse, 
                      tags=['Conteúdo'],
                      summary='Criar um novo conteúdo'
@@ -20,7 +20,7 @@ def create_content(
     return content.create_content(new_content_data, db)
 
 
-@content_router.get('/list-contents/',
+@router.get('/list-contents/',
                     response_model=list[ContentResponse],
                     tags=['Conteúdo'],
                     summary='Listar conteúdos'
@@ -29,7 +29,7 @@ def list_contents(db: Session = Depends(get_session)):
     return content.list_contents(db)
 
 
-@content_router.put('/update-content/{content_id}', 
+@router.put('/update-content/{content_id}', 
                     response_model=ContentResponse, 
                     tags=['Conteúdo'],
                     summary='Atualizar um conteúdo'
@@ -41,7 +41,7 @@ def update_content(content_id: int,
     return content.update_content(content_id, content_update_data, db)
 
 
-@content_router.delete('/delete/{content_id}',
+@router.delete('/delete/{content_id}',
                        response_model=ContentResponse,
                        tags=['Conteúdo'],
                        summary='Deletar um conteúdo'

--- a/app/api/routes/content.py
+++ b/app/api/routes/content.py
@@ -1,8 +1,7 @@
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
+from fastapi import APIRouter
 
 from app.schemas.content import ContentCreate, ContentResponse, ContentUpdate
-from app.core.db_provider import get_session
+from app.api.dependencies import SessionDep
 from app.services import content
 
 router = APIRouter()
@@ -15,7 +14,7 @@ router = APIRouter()
 )
 def create_content(
     new_content_data: ContentCreate,
-    db: Session = Depends(get_session)
+    db: SessionDep
 ):
     return content.create_content(new_content_data, db)
 
@@ -25,7 +24,7 @@ def create_content(
                     tags=['Conteúdo'],
                     summary='Listar conteúdos'
 )
-def list_contents(db: Session = Depends(get_session)):
+def list_contents(db: SessionDep):
     return content.list_contents(db)
 
 
@@ -36,7 +35,7 @@ def list_contents(db: Session = Depends(get_session)):
 )
 def update_content(content_id: int, 
                    content_update_data: ContentUpdate,
-                   db: Session = Depends(get_session)
+                   db: SessionDep
 ):
     return content.update_content(content_id, content_update_data, db)
 
@@ -46,5 +45,5 @@ def update_content(content_id: int,
                        tags=['Conteúdo'],
                        summary='Deletar um conteúdo'
 )
-def delete_content(content_id: int, db: Session = Depends(get_session)):
+def delete_content(content_id: int, db: SessionDep):
     return content.delete_content(content_id, db)

--- a/app/api/routes/content.py
+++ b/app/api/routes/content.py
@@ -4,46 +4,26 @@ from app.schemas.content import ContentCreate, ContentResponse, ContentUpdate
 from app.api.dependencies import SessionDep
 from app.services import content
 
-router = APIRouter()
+router = APIRouter(prefix='/content', tags=['Conteúdo'])
 
 
-@router.post('/create-content/', 
-                     response_model=ContentResponse, 
-                     tags=['Conteúdo'],
-                     summary='Criar um novo conteúdo'
-)
-def create_content(
-    new_content_data: ContentCreate,
-    db: SessionDep
-):
+@router.post('/create/', response_model=ContentResponse)
+def create_content(new_content_data: ContentCreate, db: SessionDep):
     return content.create_content(new_content_data, db)
 
 
-@router.get('/list-contents/',
-                    response_model=list[ContentResponse],
-                    tags=['Conteúdo'],
-                    summary='Listar conteúdos'
-)
+@router.get('/list/', response_model=list[ContentResponse])
 def list_contents(db: SessionDep):
     return content.list_contents(db)
 
 
-@router.put('/update-content/{content_id}', 
-                    response_model=ContentResponse, 
-                    tags=['Conteúdo'],
-                    summary='Atualizar um conteúdo'
-)
-def update_content(content_id: int, 
-                   content_update_data: ContentUpdate,
-                   db: SessionDep
-):
+@router.put('/update/{content_id}', response_model=ContentResponse)
+def update_content(
+        content_id: int, content_update_data: ContentUpdate, db: SessionDep
+        ):
     return content.update_content(content_id, content_update_data, db)
 
 
-@router.delete('/delete/{content_id}',
-                       response_model=ContentResponse,
-                       tags=['Conteúdo'],
-                       summary='Deletar um conteúdo'
-)
+@router.delete('/delete/{content_id}', response_model=ContentResponse)
 def delete_content(content_id: int, db: SessionDep):
     return content.delete_content(content_id, db)

--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -1,8 +1,7 @@
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
+from fastapi import APIRouter
 
 from app.schemas.user import UserCreate, UserResponse, UserUpdate
-from app.core.db_provider import get_session
+from app.api.dependencies import SessionDep
 from app.services import user
 
 router = APIRouter()
@@ -15,7 +14,7 @@ router = APIRouter()
 )
 def create_user(
     new_user_data: UserCreate,
-    db: Session = Depends(get_session)
+    db: SessionDep
 ):
     return user.create_user(new_user_data, db)
 
@@ -25,7 +24,7 @@ def create_user(
                  tags=['Usuários'],
                  summary='Listar usuários'
 )
-def list_users(db: Session = Depends(get_session)):
+def list_users(db: SessionDep):
     return user.list_users(db)
 
 
@@ -37,7 +36,7 @@ def list_users(db: Session = Depends(get_session)):
 def update_user(
     user_id: int,
     user_update_data: UserUpdate,
-    db: Session = Depends(get_session)
+    db: SessionDep
 ):
     return user.update_user(user_id, user_update_data, db)
 
@@ -48,6 +47,6 @@ def update_user(
                     summary='Deletar um usuário'
 )
 def delete_user(user_id: int, 
-                db: Session = Depends(get_session)
+                db: SessionDep
 ):
     return user.delete_user(user_id, db)

--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -5,10 +5,10 @@ from app.schemas.user import UserCreate, UserResponse, UserUpdate
 from app.core.db_provider import get_session
 from app.services import user
 
-user_router = APIRouter()
+router = APIRouter()
 
 
-@user_router.post('/new-user/', 
+@router.post('/new-user/', 
                 response_model=UserResponse, 
                 tags=['Usuários'],
                 summary='Adicionar um novo usuário'
@@ -20,7 +20,7 @@ def create_user(
     return user.create_user(new_user_data, db)
 
 
-@user_router.get('/list-users/', 
+@router.get('/list-users/', 
                  response_model=list[UserResponse], 
                  tags=['Usuários'],
                  summary='Listar usuários'
@@ -29,7 +29,7 @@ def list_users(db: Session = Depends(get_session)):
     return user.list_users(db)
 
 
-@user_router.put('/update-user/{user_id}/', 
+@router.put('/update-user/{user_id}/', 
                  response_model=UserResponse, 
                  tags=['Usuários'],
                  summary='Atualizar dados do usuário'
@@ -42,7 +42,7 @@ def update_user(
     return user.update_user(user_id, user_update_data, db)
 
 
-@user_router.delete('/delete-user/{user_id}', 
+@router.delete('/delete-user/{user_id}', 
                     response_model=UserResponse, 
                     tags=['Usuários'],
                     summary='Deletar um usuário'

--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -4,49 +4,24 @@ from app.schemas.user import UserCreate, UserResponse, UserUpdate
 from app.api.dependencies import SessionDep
 from app.services import user
 
-router = APIRouter()
+router = APIRouter(prefix='/user', tags=['Usuários'])
 
 
-@router.post('/new-user/', 
-                response_model=UserResponse, 
-                tags=['Usuários'],
-                summary='Adicionar um novo usuário'
-)
-def create_user(
-    new_user_data: UserCreate,
-    db: SessionDep
-):
+@router.post('/new/', response_model=UserResponse)
+def create_user(new_user_data: UserCreate, db: SessionDep):
     return user.create_user(new_user_data, db)
 
 
-@router.get('/list-users/', 
-                 response_model=list[UserResponse], 
-                 tags=['Usuários'],
-                 summary='Listar usuários'
-)
+@router.get('/list/', response_model=list[UserResponse])
 def list_users(db: SessionDep):
     return user.list_users(db)
 
 
-@router.put('/update-user/{user_id}/', 
-                 response_model=UserResponse, 
-                 tags=['Usuários'],
-                 summary='Atualizar dados do usuário'
-)
-def update_user(
-    user_id: int,
-    user_update_data: UserUpdate,
-    db: SessionDep
-):
+@router.put('/update/{user_id}/', response_model=UserResponse)
+def update_user(user_id: int, user_update_data: UserUpdate, db: SessionDep):
     return user.update_user(user_id, user_update_data, db)
 
 
-@router.delete('/delete-user/{user_id}', 
-                    response_model=UserResponse, 
-                    tags=['Usuários'],
-                    summary='Deletar um usuário'
-)
-def delete_user(user_id: int, 
-                db: SessionDep
-):
+@router.delete('/delete/{user_id}', response_model=UserResponse)
+def delete_user(user_id: int, db: SessionDep):
     return user.delete_user(user_id, db)

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,11 @@
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI
 
-from app.api.routes.content import content_router
-from app.api.routes.user import user_router
+from app.api.main import api_router
 
 app = FastAPI()
 
-app.include_router(user_router)
-app.include_router(content_router)
+app.include_router(api_router)
 
 # origins = [""] # Lista de origens permitidas
 


### PR DESCRIPTION
# Rotas: simplifica importação e refatoração do código

## O que foi feito
- Centraliza a gestão de rotas em `app/api/main.py` e facilita sua importação no módulo principal da aplicação
- Define `tags` e `prefix` diretamente no `APIRouter` do módulo 
- Cria dependência tipada para injeção banco de dados
- Refatora e faz ajustes de estilo para atender aos padrões da PEP8
- Adiciona banco de dados de teste ao `.gitignore`
